### PR TITLE
Remove babel polyfill

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -53,17 +53,34 @@ module.exports = {
                     {
                         loader: "babel-loader",
                         options: {
+                            sourceType: "unambiguous",
                             presets: [
                                 process.env.NODE_ENV === "development"
                                     ? [
                                           "@babel/preset-env",
                                           {
                                               targets: {
-                                                  browsers: ["last 2 years"]
-                                              }
+                                                browsers: ["last 2 years"]
+                                              },
+                                              useBuiltIns: "usage",
+                                              corejs: "3"
                                           }
                                       ]
-                                    : "@babel/preset-env"
+                                    : [
+                                        "@babel/preset-env",
+                                        {
+                                            useBuiltIns: "usage",
+                                            corejs: "3"
+                                        }
+                                    ]
+                            ],
+                            plugins: [
+                                [
+                                    "@babel/plugin-transform-runtime",
+                                    {
+                                        regenerator: true
+                                    }
+                                ]
                             ]
                         }
                     },

--- a/package.json
+++ b/package.json
@@ -30,8 +30,11 @@
     },
     "dependencies": {
         "@babel/core": "^7.11.5",
+        "@babel/plugin-transform-runtime": "^7.11.5",
         "@babel/preset-env": "^7.11.5",
+        "@babel/runtime": "^7.11.2",
         "babel-loader": "^8.1.0",
+        "core-js": "^3.6.5",
         "cross-env": "^7.0.2",
         "css-loader": "^4.2.2",
         "eslint": "^7.8.1",


### PR DESCRIPTION
Following the [deprecation](https://babeljs.io/docs/en/babel-preset-env#usebuiltins) of `@babel/polyfill`, uses the new recommended method.