### PR TITLE
Fix incompatible "html-webpack-plugin" version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "eslint-webpack-plugin": "^2.5.3",
         "fibers": "^5.0.0",
         "file-loader": "^6.2.0",
-        "html-webpack-plugin": "^5.3.1",
+        "html-webpack-plugin": "^4.5.2",
         "npm-check-updates": "^11.3.0",
         "prettier": "^2.2.1",
         "prettier-config-hive": "^0.1.7",


### PR DESCRIPTION
**Issue:**<br>
This error is shown in one of our projects:
```
TypeError: Cannot read property 'tap' of undefined
    at HtmlWebpackPlugin.apply (E:\Projetos\Platforme\ripe-pulse\node_modules\html-webpack-plugin\index.js:40:31)
    at webpack (E:\Projetos\Platforme\ripe-pulse\node_modules\webpack\lib\webpack.js:51:13)
    at startDevServer (E:\Projetos\Platforme\ripe-pulse\node_modules\webpack-dev-server\bin\webpack-dev-server.js:94:16)        
    at E:\Projetos\Platforme\ripe-pulse\node_modules\webpack-dev-server\bin\webpack-dev-server.js:166:3
    at E:\Projetos\Platforme\ripe-pulse\node_modules\webpack-dev-server\lib\utils\processOptions.js:33:9]
```

To fix this we need to set the package `html-webpack-plugin` to `v4` so it can work with `webpack v4` (see https://www.npmjs.com/package/html-webpack-plugin install section)

The reason this error doesn't appear in other projects is because those projects use storybook and storybook is forcing `html-webpack-plugin v4` (see https://github.com/storybookjs/storybook/blob/0b1135e1dfe9258432e11c2ff3789902ab01a6e5/lib/builder-webpack4/package.json#L91) so all the versions are aligned and all runs smoothly